### PR TITLE
v2.9.0; add rudimentary support to modify issues

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@
 
 (nothing yet)
 
+## 2.9.0
+
+- Add rudimentary support to modify issues,
+  `jira issue set ...`
+
 ## 2.8.1
 
 - Fix `jirash issue list ...` crash on an issue that does not have a "priority"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
 ## 2.9.0
 
 - Add rudimentary support to modify issues,
-  `jira issue set ...`
+  `jirash issue edit ...`
 
 ## 2.8.1
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ A full JSON dump of REST API data for the issue:
     AGENT-1080  hagfish-watcher should use sdcnode        josh.clulow  trent.mick  4  Open  2017-07-14  2017-07-14
     ...
 
+**Edit an issue:**
+
+    This is less user-friendly than other commands, but allows you more control
+    over editing issues. For more information on JSON accepted, see the Jira API
+    docs:
+    https://docs.atlassian.com/software/jira/docs/api/REST/7.4.2/#api/2/issue-editIssue
+
+    $ jirash issue edit TRITON-1140 '{"labels": [{"add": "lullaby-phase2"}]}'
+
 
 # Configuration Reference
 

--- a/lib/cli/do_issue/do_edit.js
+++ b/lib/cli/do_issue/do_edit.js
@@ -4,8 +4,6 @@
  * `jirash issue edit ISSUE EDIT-JSON`
  */
 
-var format = require('util').format;
-
 var UsageError = require('cmdln').UsageError;
 var vasync = require('vasync');
 
@@ -21,7 +19,7 @@ function do_edit(subcmd, opts, args, cb) {
     var key = args[0];
     var issueData;
     try {
-        issueData = {"update": JSON.parse(args[1])};
+        issueData = {'update': JSON.parse(args[1])};
     } catch (parseErr) {
         cb(new UsageError('could not parse EDIT-JSON: ' + parseErr.message));
         return;
@@ -68,6 +66,7 @@ do_edit.help = [
     '',
     '{{options}}',
     'This is currently a raw interface to the "Edit issue" Jira REST API.',
+    // eslint-disable-next-line max-len
     'See https://docs.atlassian.com/software/jira/docs/api/REST/7.4.2/#api/2/issue-editIssue',
     'for details on the format of EDIT-JSON.',
     '',
@@ -77,6 +76,7 @@ do_edit.help = [
     '- Remove a label:',
     '    jirash issue edit TOOLS-2179 \'{"labels": [{"remove": "spout"}]}\'',
     '- Set the summary:',
+    // eslint-disable-next-line max-len
     '    jirash issue edit TOOLS-2179 \'{"summary": [{"set": "This is my handle"}]}\''
 ].join('\n');
 

--- a/lib/cli/do_issue/do_edit.js
+++ b/lib/cli/do_issue/do_edit.js
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2019, Joyent, Inc.
+ *
+ * `jirash issue edit ISSUE EDIT-JSON`
+ */
+
+var format = require('util').format;
+
+var UsageError = require('cmdln').UsageError;
+var vasync = require('vasync');
+
+function do_edit(subcmd, opts, args, cb) {
+    if (opts.help) {
+        this.do_help('help', {}, [subcmd], cb);
+        return;
+    } else if (args.length !== 2) {
+        cb(new UsageError('incorrect number of args'));
+        return;
+    }
+
+    var key = args[0];
+    var issueData;
+    try {
+        issueData = {"update": JSON.parse(args[1])};
+    } catch (parseErr) {
+        cb(new UsageError('could not parse EDIT-JSON: ' + parseErr.message));
+        return;
+    }
+
+    vasync.pipeline(
+        {
+            arg: {cli: this.top},
+            funcs: [
+                function editIssue(ctx, next) {
+                    ctx.cli.jirashApi.editIssue(
+                        {
+                            issueIdOrKey: key,
+                            issueData: issueData
+                        },
+                        function onIssue(err, issue) {
+                            ctx.issue = issue;
+                            next(err);
+                        }
+                    );
+                }
+            ]
+        },
+        cb
+    );
+}
+
+do_edit.options = [
+    {
+        names: ['help', 'h'],
+        type: 'bool',
+        help: 'Show this help.'
+    }
+];
+
+do_edit.synopses = ['{{name}} {{cmd}} [OPTIONS] ISSUE EDIT-JSON'];
+
+do_edit.completionArgtypes = ['jirashissue', 'none'];
+
+do_edit.help = [
+    'Modify an issue using issue-edit operations',
+    '',
+    '{{usage}}',
+    '',
+    '{{options}}',
+    'This is currently a raw interface to the "Edit issue" Jira REST API.',
+    'See https://docs.atlassian.com/software/jira/docs/api/REST/7.4.2/#api/2/issue-editIssue',
+    'for details on the format of EDIT-JSON.',
+    '',
+    'Examples:',
+    '- Add a label:',
+    '    jirash issue edit TOOLS-2179 \'{"labels": [{"add": "teapot"}]}\'',
+    '- Remove a label:',
+    '    jirash issue edit TOOLS-2179 \'{"labels": [{"remove": "spout"}]}\'',
+    '- Set the summary:',
+    '    jirash issue edit TOOLS-2179 \'{"summary": [{"set": "This is my handle"}]}\''
+].join('\n');
+
+module.exports = do_edit;

--- a/lib/cli/do_issue/index.js
+++ b/lib/cli/do_issue/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Joyent, Inc.
+ * Copyright (c) 2019, Joyent, Inc.
  *
  * `jirash issue ...`
  */
@@ -13,11 +13,12 @@ function IssueCli(top) {
     this.top = top;
     Cmdln.call(this, {
         name: top.name + ' issue',
-        desc: ['Search, get, and create JIRA issues.'].join('\n'),
+        desc: ['Search, get, edit, and create JIRA issues.'].join('\n'),
         helpOpts: {
             minHelpCol: 24 /* line up with option help */
         },
-        helpSubcmds: ['help', 'list', 'get', 'create', 'link', 'linktypes']
+        helpSubcmds: ['help', 'list', 'get', 'create', 'link', 'linktypes',
+            'edit']
     });
 }
 util.inherits(IssueCli, Cmdln);
@@ -30,5 +31,6 @@ IssueCli.prototype.do_get = require('./do_get');
 IssueCli.prototype.do_create = require('./do_create');
 IssueCli.prototype.do_link = require('./do_link');
 IssueCli.prototype.do_linktypes = require('./do_linktypes');
+IssueCli.prototype.do_edit = require('./do_edit');
 
 module.exports = IssueCli;

--- a/lib/jirashapi.js
+++ b/lib/jirashapi.js
@@ -449,7 +449,7 @@ JirashApi.prototype.editIssue = function editIssue(opts, cb) {
     assert.object(opts.issueData, 'opts.issueData');
 
     var context = {
-        api: this,
+        api: this
     };
 
     vasync.pipeline(
@@ -462,7 +462,7 @@ JirashApi.prototype.editIssue = function editIssue(opts, cb) {
                     ctx.jiraClient.put(
                         {
                             path: format('/rest/api/2/issue/%s',
-			        opts.issueIdOrKey),
+                                opts.issueIdOrKey)
                         },
                         opts.issueData,
                         function onRes(err, req, res, body) {
@@ -854,7 +854,7 @@ JirashApi.prototype.createSearchStream = function createSearchStream(opts) {
     assert.optionalArrayOfString(opts.fields, 'opts.fields');
     assert.optionalArrayOfString(opts.expand, 'opts.expand');
 
-    var baseSearchOpts =  {
+    var baseSearchOpts = {
         jql: opts.jql
     };
     if (has(opts, 'validateQuery')) {

--- a/lib/jirashapi.js
+++ b/lib/jirashapi.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Joyent, Inc.
+ * Copyright (c) 2019, Joyent, Inc.
  */
 
 /*
@@ -433,6 +433,49 @@ JirashApi.prototype.linkIssues = function linkIssues(opts, cb) {
         },
         function finished(err) {
             cb(err);
+        }
+    );
+};
+
+/*
+ * Edit issue
+ * https://docs.atlassian.com/software/jira/docs/api/REST/7.4.2/#api/2/issue-editIssue
+ */
+JirashApi.prototype.editIssue = function editIssue(opts, cb) {
+    assert.object(opts, 'opts');
+    assert.string(opts.issueIdOrKey, 'opts.issueIdOrKey');
+    assert.object(opts.issueData, 'opts.IssueData');
+
+    var context = {
+        api: this,
+    };
+
+    vasync.pipeline(
+        {
+            arg: context,
+            funcs: [
+                ctxJiraClient,
+
+                function putIt(ctx, next) {
+                    ctx.jiraClient.put(
+                        {
+                            path: format('/rest/api/2/issue/%s', opts.issueIdOrKey),
+                        },
+                        opts.issueData,
+                        function onRes(err, req, res, body) {
+                            if (err) {
+                                next(err);
+                            } else {
+                                ctx.issue = body;
+                                next();
+                            }
+                        }
+                    );
+                }
+            ]
+        },
+        function finished(err) {
+            cb(err, context.issue);
         }
     );
 };

--- a/lib/jirashapi.js
+++ b/lib/jirashapi.js
@@ -437,14 +437,16 @@ JirashApi.prototype.linkIssues = function linkIssues(opts, cb) {
     );
 };
 
+/* eslint-disable max-len */
 /*
  * Edit issue
  * https://docs.atlassian.com/software/jira/docs/api/REST/7.4.2/#api/2/issue-editIssue
  */
+/* eslint-enable max-len */
 JirashApi.prototype.editIssue = function editIssue(opts, cb) {
     assert.object(opts, 'opts');
     assert.string(opts.issueIdOrKey, 'opts.issueIdOrKey');
-    assert.object(opts.issueData, 'opts.IssueData');
+    assert.object(opts.issueData, 'opts.issueData');
 
     var context = {
         api: this,
@@ -459,7 +461,8 @@ JirashApi.prototype.editIssue = function editIssue(opts, cb) {
                 function putIt(ctx, next) {
                     ctx.jiraClient.put(
                         {
-                            path: format('/rest/api/2/issue/%s', opts.issueIdOrKey),
+                            path: format('/rest/api/2/issue/%s',
+			        opts.issueIdOrKey),
                         },
                         opts.issueData,
                         function onRes(err, req, res, body) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jirash",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "description": "a JIRA CLI",
   "main": "./lib/index.js",
   "bin": {


### PR DESCRIPTION
The CLI here isn't wonderful admittedly, but seems marginally better than trying to add multiple operators for the myriad of ways in which a power-user may wish to modify an issue.

The command name 'set' really ought to be 'edit', but I felt that since jirash already has a 'get' command, using 'set' for this change would be more intuitive.