### PR TITLE
v2.10.0; add 'jirash issue comment' support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@
 
 (nothing yet)
 
+## 2.10.0
+
+- Add support to add comments to issues,
+  `jirash issue comment ISSUE <file|->`
+
 ## 2.9.0
 
 - Add rudimentary support to modify issues,

--- a/TODO.md
+++ b/TODO.md
@@ -30,7 +30,7 @@
 
 # old todos
 
-- add "jirash comment KEY", and -m option (or following args?) on resolve:
+- add -m option (or following args?) on resolve:
         jirash resolve FOO-123 because this is what I did
         jirash resolve FOO-123 -m "because this is what I did"
 - tab complete for project names
@@ -38,12 +38,7 @@
 - '--cc' field in `jirash createissue` to add watchers. Perhaps '-w', '--watch'.
 - listing users
 - updateIssue commands
-- adding a comment:
-    $ jirash comment MON-113 blah bah blah
-    $ jirash comment MON-113
-    blah blah
-    blah
-    .
+
 - `jirash dup(licate) MON-113 of MON-114`  Yes, a literal "of" to try to
   help make clear which is the dupe. Doesn't read quite right:
 

--- a/lib/cli/do_issue/do_comment.js
+++ b/lib/cli/do_issue/do_comment.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2019, Joyent, Inc.
+ *
+ * `jirash issue comment ISSUE <file>|-`
+ */
+
+var UsageError = require('cmdln').UsageError;
+var vasync = require('vasync');
+var fs = require('fs');
+
+function do_comment(subcmd, opts, args, cb) {
+    if (opts.help) {
+        this.do_help('help', {}, [subcmd], cb);
+        return;
+    } else if (args.length !== 2) {
+        cb(new UsageError('incorrect number of args'));
+        return;
+    }
+
+    var context = {
+        cli: this.top
+    };
+
+    var key = args[0];
+    var commentFile = args[1];
+
+    if (commentFile === '-') {
+        commentFile = '/dev/stdin';
+    }
+
+    fs.readFile(commentFile, 'utf-8', function addComment(err, data) {
+        if (err) {
+            cb(new Error('unable to read file: ' + err));
+            return;
+        }
+        vasync.pipeline(
+            {
+                arg: context,
+                funcs: [
+                    function commentIssue(ctx, next) {
+                        ctx.cli.jirashApi.commentIssue(
+                            {
+                                issueIdOrKey: key,
+                                issueComment: data
+                            },
+                            function onIssue(ierr, issue) {
+                                ctx.issue = issue;
+                                next(ierr);
+                            }
+                        );
+                    }
+                ]
+            },
+            cb
+        );
+    });
+}
+
+do_comment.options = [
+    {
+        names: ['help', 'h'],
+        type: 'bool',
+        help: 'Show this help.'
+    }
+];
+
+do_comment.synopses = ['{{name}} {{cmd}} [OPTIONS] ISSUE FILE'];
+
+do_comment.completionArgtypes = ['jirashissue', 'none'];
+
+do_comment.help = [
+    'Add a comment to an issue',
+    '',
+    '{{usage}}',
+    '',
+    '{{options}}',
+    'Reads a file or stdin and adds that text to the issue',
+    '',
+    'Examples:',
+    '    cat comment.txt | jirash issue comment TOOLS-2179 -',
+    '    jirash issue comment TOOLS-2179 mycomment.md'
+].join('\n');
+
+module.exports = do_comment;

--- a/lib/cli/do_issue/index.js
+++ b/lib/cli/do_issue/index.js
@@ -13,12 +13,13 @@ function IssueCli(top) {
     this.top = top;
     Cmdln.call(this, {
         name: top.name + ' issue',
-        desc: ['Search, get, edit, and create JIRA issues.'].join('\n'),
+        desc: ['Search, get, edit, comment on and create JIRA issues.'].join(
+            '\n'),
         helpOpts: {
             minHelpCol: 24 /* line up with option help */
         },
         helpSubcmds: ['help', 'list', 'get', 'create', 'link', 'linktypes',
-            'edit']
+            'edit', 'comment']
     });
 }
 util.inherits(IssueCli, Cmdln);
@@ -32,5 +33,6 @@ IssueCli.prototype.do_create = require('./do_create');
 IssueCli.prototype.do_link = require('./do_link');
 IssueCli.prototype.do_linktypes = require('./do_linktypes');
 IssueCli.prototype.do_edit = require('./do_edit');
+IssueCli.prototype.do_comment = require('./do_comment');
 
 module.exports = IssueCli;

--- a/lib/jirashapi.js
+++ b/lib/jirashapi.js
@@ -483,6 +483,54 @@ JirashApi.prototype.editIssue = function editIssue(opts, cb) {
     );
 };
 
+/* eslint-disable max-len */
+/*
+ * Comment on an issue
+ * https://docs.atlassian.com/software/jira/docs/api/REST/7.4.2/#api/2/issue-addComment
+ */
+/* eslint-enable max-len */
+JirashApi.prototype.commentIssue = function commentIssue(opts, cb) {
+    assert.object(opts, 'opts');
+    assert.string(opts.issueIdOrKey, 'opts.issueIdOrKey');
+    assert.string(opts.issueComment, 'opts.issueComment');
+
+    var context = {
+        api: this
+    };
+
+    var post = {'body': opts.issueComment};
+
+    vasync.pipeline(
+        {
+            arg: context,
+            funcs: [
+                ctxJiraClient,
+
+                function putIt(ctx, next) {
+                    ctx.jiraClient.post(
+                        {
+                            path: format('/rest/api/2/issue/%s/comment',
+                                opts.issueIdOrKey)
+                        },
+                        post,
+                        function onRes(err, req, res, body) {
+                            if (err) {
+                                next(err);
+                            } else {
+                                ctx.issue = body;
+                                next();
+                            }
+                        }
+                    );
+                }
+            ]
+        },
+        function finished(err) {
+            cb(err, context.issue);
+        }
+    );
+};
+
 /*
  * Get metadata relevant for createIssue.
  * https://docs.atlassian.com/jira/REST/cloud/#api/2/issue-getCreateIssueMeta

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jirash",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "a JIRA CLI",
   "main": "./lib/index.js",
   "bin": {


### PR DESCRIPTION
This allows us to read a comment from a flat file (passed through verbatim) or from stdin. I've tested it with a 30k text file, as well as small one-line comments from the command line. There's very little in the way of user interface, notably, when taking stdin, we don't prompt the user or advise them to ^D to finish - should we?